### PR TITLE
feat: pull in prompts from api endpoint, allow re-runs of analysis

### DIFF
--- a/ai-prompts/cia-analyst.md
+++ b/ai-prompts/cia-analyst.md
@@ -1,3 +1,5 @@
+You are a CIA analyst on the Stargate remote viewing program.
+
 The notes below summarize the results of a remote viewing session.
 
 Review the notes and score the session based on the following rubric:

--- a/app/components/EEGNotes/EEGNotes.tsx
+++ b/app/components/EEGNotes/EEGNotes.tsx
@@ -27,7 +27,16 @@ export function EEGNotes({ sessionId, initialNotes }: EEGNotesProps) {
             <Textarea
               id="notes"
               name="notes"
-              placeholder="Write your thoughts about this session..."
+              placeholder={`Example Session Notes
+
+Target:
+
+- Location: {Description or GPS coordinates}
+- Time: {Target viewing time}
+
+Report: 
+
+{Remote viewer notes, PDF extract, or audio transcript}`}
               value={notes}
               onChange={e => setNotes(e.target.value)}
               className="min-h-[200px]"

--- a/app/routes/api.prompts.ts
+++ b/app/routes/api.prompts.ts
@@ -1,0 +1,24 @@
+import type { LoaderFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Returns a list of available prompt templates from the ai-prompts directory.
+ */
+export const loader: LoaderFunction = async () => {
+  try {
+    const promptsDir = path.join(process.cwd(), 'ai-prompts');
+    const files = await fs.readdir(promptsDir);
+    const prompts = files
+      .filter((name) => name.endsWith('.md'))
+      .map((name) => name.replace(/\.md$/, ''));
+    return json({ prompts });
+  } catch (error) {
+    console.error('Error reading ai-prompts directory:', error);
+    return json({ prompts: [] });
+  }
+};
+export const headers = {
+  'Cache-Control': 'no-cache',
+};


### PR DESCRIPTION
- Pull in prompt templates from `api-prompts` directory
- Allow user to re-run the analysis